### PR TITLE
Updated to reference root namespace \Exception

### DIFF
--- a/src/MailgunValidator.php
+++ b/src/MailgunValidator.php
@@ -43,7 +43,7 @@ class MailgunValidator
         curl_close($curl);
 
         if ($err) {
-            throw new Exception('Curl Error: ' . $err);
+            throw new \Exception('Curl Error: ' . $err);
         } else {
             return json_decode($response);
         }


### PR DESCRIPTION
If you ever got a curl error you would actually end up with an exception from trying to throw the exception:

`Class 'overint\Exception' not found`